### PR TITLE
send etag, accept patch

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,17 +8,20 @@ Bundler.require(*Rails.groups)
 
 module Giona
   class Application < Rails::Application
-    # Settings in config/environments/* take precedence over those specified here.
+    # Settings in config/environments/* take precedence over
+    # those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.time_zone = 'Europe/Stockholm'
-    config.middleware.insert_before 0, Rack::Cors, :debug => true, :logger => Rails.logger do #TODO tighten up
+    config.middleware.insert_before 0, Rack::Cors, :debug => true,
+                                    :logger => Rails.logger do #TODO tighten up
       allow do
         origins '*'
-        resource '*', 
-        :headers => :any, 
-        :expose  => ['access-token', 'expiry', 'token-type', 'uid', 'client'],
-        :methods => [:get, :post, :options, :delete, :put]
+        resource '*',
+        :headers => :any,
+        :expose  => ['access-token', 'etag', 'expiry',
+                     'token-type', 'uid', 'client'],
+        :methods => [:get, :post, :options, :delete, :put, :patch]
       end
     end
 


### PR DESCRIPTION
ETag is used by app for caching data, to avoid unnecessary traffic
PATCH is used by app to modify a log entry